### PR TITLE
Additional loader options

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -177,6 +177,20 @@ instance isForeignOptions :: IsForeign Options
 ```
 
 
+#### `booleanLoaderOption`
+
+``` purescript
+instance booleanLoaderOption :: LoaderOption Boolean
+```
+
+
+#### `stringLoaderOption`
+
+``` purescript
+instance stringLoaderOption :: LoaderOption String
+```
+
+
 #### `pscMakeOutputOption`
 
 ``` purescript
@@ -188,6 +202,13 @@ pscMakeOutputOption :: Foreign -> Maybe String
 
 ``` purescript
 pscMakeOptions :: Foreign -> [String]
+```
+
+
+#### `loaderSrcOption`
+
+``` purescript
+loaderSrcOption :: Foreign -> Maybe [String]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,41 @@ npm install purs-loader --save-dev
 
 ## Options
 
- - **no-prelude**: Boolean value that toggles `--no-prelude`
-  - Do not include the Prelude in the generated Javascript.
- - **no-opts**: Boolean value that toggles `--no-opts`
-  - Disable all optimizations.
- - **no-magic-do**: Boolean value that toggles `--no-magic-do`
-  - Turn off optimizations which inline calls to >>= for the Eff monad.
- - **no-tco**: Boolean value that toggles `--no-tco`
-  - Turn off tail-call elimination.
- - **verbose-errors**: Boolean value that toggles `--verbose-errors`
-  - Generate verbose error messages.
- - **output**: String value that sets `--output=<string>`
-  - Write the generated Javascript to the specified file.
+###### `noPrelude` (Boolean)
+
+Toggles `--no-prelude` that omits the Prelude.
+
+###### `noTco` (Boolean)
+
+Toggles `--no-tco` that disables tail-call optimizations.
+
+###### `noMagicDo` (Boolean)
+
+Toggles `--no-magic-do` that disables optimizations overloading the do keyword generating efficient code for the `Eff` monad.
+
+###### `noOpts` (Boolean)
+
+Toggles `--no-opts` that skips the optimization phase.
+
+###### `verboseErrors` (Boolean)
+
+Toggles `--verbose-errors` that displays verbose error messages.
+
+###### `comments` (Boolean)
+
+Toggles `--comments` that includes comments in generated code.
+
+###### `output` (String)
+
+Sets `--output=<string>` the specifies the output directory, `output` by default.
+
+###### `noPrefix` (Boolean)
+
+Toggles `--no-prefix` that does not include the comment header.
+
+###### `src` (String Array)
+
+Specifies PureScript source paths to be globbed for `.purs` files. By default, `bower_components` is search. Additional paths may be specified using this option. This option is specified as `src[]=path`.
 
 ## Example
 

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -5,7 +5,7 @@ var config
     , output: { path: __dirname
               , filename: 'bundle.js'
               }
-    , module: { loaders: [ { test: /\.purs$/, loader: 'purs-loader' } ] }
+    , module: { loaders: [ { test: /\.purs$/, loader: 'purs-loader?src[]=src' } ] }
     , resolve: { modulesDirectories: [ 'node_modules',
                                        'output'
                                      ]

--- a/src/Options.purs
+++ b/src/Options.purs
@@ -2,6 +2,7 @@ module PursLoader.Options
   ( pscMakeOptions
   , pscMakeDefaultOutput
   , pscMakeOutputOption
+  , loaderSrcOption
   ) where
 
 import Data.Either (either)
@@ -24,6 +25,12 @@ verboseErrorsOpt = "verbose-errors"
 
 outputOpt = "output"
 
+commentsOpt = "comments"
+
+noPrefixOpt = "no-prefix"
+
+srcOpt = "src"
+
 pscMakeDefaultOutput = "output"
 
 newtype Options
@@ -32,29 +39,42 @@ newtype Options
             , noMagicDo :: NullOrUndefined Boolean
             , noTco :: NullOrUndefined Boolean
             , verboseErrors :: NullOrUndefined Boolean
+            , comments :: NullOrUndefined Boolean
             , output :: NullOrUndefined String
+            , noPrefix :: NullOrUndefined Boolean
+            , src :: NullOrUndefined [String]
             }
 
 instance isForeignOptions :: IsForeign Options where
-  read obj = (\a b c d e f ->
-             Options { noPrelude: a
-                     , noOpts: b
-                     , noMagicDo: c
-                     , noTco: d
-                     , verboseErrors: e
-                     , output: f
-                     }) <$> readProp noPreludeOpt obj
-                        <*> readProp noOptsOpt obj
-                        <*> readProp noMagicDoOpt obj
-                        <*> readProp noTcoOpt obj
-                        <*> readProp verboseErrorsOpt obj
-                        <*> readProp outputOpt obj
+  read obj = Options <$> ({ noPrelude: _
+                          , noOpts: _
+                          , noMagicDo: _
+                          , noTco: _
+                          , verboseErrors: _
+                          , comments: _
+                          , output: _
+                          , noPrefix: _
+                          , src: _
+                          } <$> readProp noPreludeOpt obj
+                            <*> readProp noOptsOpt obj
+                            <*> readProp noMagicDoOpt obj
+                            <*> readProp noTcoOpt obj
+                            <*> readProp verboseErrorsOpt obj
+                            <*> readProp commentsOpt obj
+                            <*> readProp outputOpt obj
+                            <*> readProp noPrefixOpt obj
+                            <*> readProp srcOpt obj)
 
-booleanOpt :: String -> NullOrUndefined Boolean -> [String]
-booleanOpt key opt = maybe [] (\a -> if a then ["--" ++ key] else []) (runNullOrUndefined opt)
+class LoaderOption a where
+  opt :: String -> NullOrUndefined a -> [String]
 
-stringOpt :: String -> NullOrUndefined String -> [String]
-stringOpt key opt = maybe [] (\a -> ["--" ++ key ++ "=" ++ a]) (runNullOrUndefined opt)
+instance booleanLoaderOption :: LoaderOption Boolean where
+  opt key opt = maybe [] (\a -> if a then ["--" ++ key] else [])
+                         (runNullOrUndefined opt)
+
+instance stringLoaderOption :: LoaderOption String where
+  opt key opt = maybe [] (\a -> ["--" ++ key ++ "=" ++ a])
+                         (runNullOrUndefined opt)
 
 pscMakeOutputOption :: Foreign -> Maybe String
 pscMakeOutputOption query = either (const Nothing)
@@ -64,9 +84,16 @@ pscMakeOutputOption query = either (const Nothing)
 pscMakeOptions :: Foreign -> [String]
 pscMakeOptions query = either (const []) fold parsed
   where parsed = read query :: F Options
-        fold (Options a) = booleanOpt noPreludeOpt a.noPrelude <>
-                           booleanOpt noOptsOpt a.noOpts <>
-                           booleanOpt noMagicDoOpt a.noMagicDo <>
-                           booleanOpt noTcoOpt a.noTco <>
-                           booleanOpt verboseErrorsOpt a.verboseErrors <>
-                           stringOpt outputOpt a.output
+        fold (Options a) = opt noPreludeOpt a.noPrelude <>
+                           opt noOptsOpt a.noOpts <>
+                           opt noMagicDoOpt a.noMagicDo <>
+                           opt noTcoOpt a.noTco <>
+                           opt verboseErrorsOpt a.verboseErrors <>
+                           opt commentsOpt a.comments <>
+                           opt outputOpt a.output <>
+                           opt noPrefixOpt a.noPrefix
+
+loaderSrcOption :: Foreign -> Maybe [String]
+loaderSrcOption query = either (const Nothing)
+                               (\(Options a) -> runNullOrUndefined a.src)
+                               (read query)


### PR DESCRIPTION
Adds the `psc-make` options `comments` and `no-prefix`. Also, an
internal option `src` has been added that is used to specify the source
paths of `PureScript` files that will be globbed for compilation.

By default the `bower_components` path is globbed, but the loader
requires that the source paths be provided for the user's code.

Resolves #12