### PR TITLE
Fix paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ Sets `--output=<string>` the specifies the output directory, `output` by default
 
 Toggles `--no-prefix` that does not include the comment header.
 
-###### `requirePath` (String)
-
-Sets `--require-path=<string>` that specifies the path prefix to use for `require()` calls in the generated JavaScript.
-
 ###### `ffi` (String Array)
 
 Specifies the PureScript FFI files setting `--ffi=<string>`. Glob syntax is supported. This option is specified as `ffi[]=path`.
@@ -73,10 +69,7 @@ var modulesDirectories = [
   'node_modules',
   // The bower component for purescript-prelude is specified here to
   // allow JavaScript files to require the 'Prelude' module globally.
-  'bower_components/purescript-prelude/src',
-  // The output directory is specified here to allow PureScript files in
-  // your source to import other PureScript modules in your source.
-  output
+  'bower_components/purescript-prelude/src'
 ];
 
 var config

--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "purs-loader",
   "private": true,
   "devDependencies": {
-    "purescript-aff": "~0.11.3",
-    "purescript-strings": "~0.6.0",
-    "purescript-foreign": "~0.6.0"
+    "purescript-aff": "^0.13.0",
+    "purescript-strings": "^0.7.0",
+    "purescript-foreign": "^0.7.0"
   }
 }

--- a/docs/PursLoader/Loader.md
+++ b/docs/PursLoader/Loader.md
@@ -3,7 +3,7 @@
 #### `Effects`
 
 ``` purescript
-type Effects eff = (cp :: ChildProcess, fs :: FS, glob :: Glob, loader :: Loader | eff)
+type Effects eff = (cp :: ChildProcess, fs :: FS, glob :: Glob, loader :: Loader, err :: EXCEPTION | eff)
 ```
 
 #### `loader`

--- a/docs/PursLoader/Options.md
+++ b/docs/PursLoader/Options.md
@@ -1,9 +1,26 @@
 ## Module PursLoader.Options
 
+#### `Options`
+
+``` purescript
+newtype Options
+```
+
+##### Instances
+``` purescript
+instance isForeignOptions :: IsForeign Options
+```
+
+#### `output`
+
+``` purescript
+output :: Options -> String
+```
+
 #### `pscOptions`
 
 ``` purescript
-pscOptions :: Foreign -> Array String
+pscOptions :: Options -> Array String
 ```
 
 #### `loaderSrcOption`

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -8,8 +8,7 @@ var output = 'output';
 
 var modulesDirectories = [
   'node_modules',
-  'bower_components/purescript-prelude/src',
-  output
+  'bower_components/purescript-prelude/src'
 ];
 
 var config

--- a/src/PursLoader/Loader.js
+++ b/src/PursLoader/Loader.js
@@ -12,8 +12,18 @@ function relative(from) {
   };
 }
 
+function joinPath(a) {
+  return function(b) {
+    return path.join(a, b);
+  };
+}
+
 exports.cwd = cwd;
 
 exports.relative = relative;
 
+exports.joinPath = joinPath;
+
 exports.resolve = path.resolve;
+
+exports.dirname = path.dirname;

--- a/src/PursLoader/Loader.purs
+++ b/src/PursLoader/Loader.purs
@@ -4,28 +4,31 @@ module PursLoader.Loader
   , loaderFn
   ) where
 
-import Prelude (Unit(), ($), (<>), (>>=), (<$>), (++), bind, flip, id, pure, return, unit)
+import Prelude (Unit(), ($), (<>), (>>=), (<$>), (++), bind, flip, id, pure, return, unit, show)
 
 import Control.Monad.Aff (Aff(), runAff)
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Eff.Exception (error)
+import Control.Monad.Eff.Exception (throwException, error, EXCEPTION())
 
 import Data.Array ((!!), concat)
 import Data.Function (Fn2(), mkFn2)
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Either (Either(..))
 import Data.String (joinWith)
 import Data.String.Regex (match, noFlags, regex, test)
 import Data.Traversable (sequence)
+import Data.Foreign (F())
+import Data.Foreign.Class (read)
 
 import PursLoader.ChildProcess (ChildProcess(), spawn)
 import PursLoader.FS (FS(), writeFileUtf8, findFileUtf8)
 import PursLoader.Glob (Glob(), globAll)
 import PursLoader.LoaderRef (LoaderRef(), Loader(), async, cacheable, query, clearDependencies, addDependency, resourcePath)
 import PursLoader.LoaderUtil (parseQuery)
-import PursLoader.Options (loaderFFIOption, loaderSrcOption, pscOptions)
+import PursLoader.Options (loaderFFIOption, loaderSrcOption, pscOptions, Options(), output)
 
-type Effects eff = (cp :: ChildProcess, fs :: FS, glob :: Glob, loader :: Loader | eff)
+type Effects eff = (cp :: ChildProcess, fs :: FS, glob :: Glob, loader :: Loader, err :: EXCEPTION | eff)
 
 moduleRegex = regex "(?:^|\\n)module\\s+([\\w\\.]+)" noFlags { ignoreCase = true }
 
@@ -44,6 +47,10 @@ foreign import cwd :: String
 foreign import relative :: String -> String -> String
 
 foreign import resolve :: String -> String
+
+foreign import dirname :: String -> String
+
+foreign import joinPath :: String -> String -> String
 
 mkPsci :: Array (Array String) -> Array (Array String) -> String
 mkPsci srcs ffis = joinWith "\n" ((loadModule <$> concat srcs) <> (loadForeign <$> concat ffis))
@@ -66,32 +73,39 @@ loader' ref source = do
   let parsed = parseQuery $ query ref
       srcs = fromMaybe [] (loaderSrcOption parsed)
       ffis = fromMaybe [] (loaderFFIOption parsed)
-      opts = pscOptions parsed
 
-  srcss <- globAll srcs
-  ffiss <- globAll ffis
+  case read parsed :: F Options of
+    Left e -> liftEff (throwException (error (show e)))
+    Right opts -> do
+      let pscOpts = pscOptions opts
 
-  let psciFile = mkPsci srcss ffiss
+      srcss <- globAll srcs
+      ffiss <- globAll ffis
 
-  writeFileUtf8 psciFilename psciFile
+      let psciFile = mkPsci srcss ffiss
 
-  let moduleName = match moduleRegex source >>= (!!!) 1 >>= id
-      hasForeign = test foreignRegex source
-      result = (\a -> "module.exports = require('" ++ a ++ "');") <$> moduleName
+      writeFileUtf8 psciFilename psciFile
 
-  liftEff (clearDependencies ref)
-  liftEff (addDependency ref (resourcePath ref))
-  liftEff (sequence $ (\src -> addDependency ref (resolve src)) <$> concat srcss)
+      let moduleName = match moduleRegex source >>= (!!!) 1 >>= id
+          hasForeign = test foreignRegex source
+          outputDir = resolve (output opts)
+          resourceDir = dirname (resourcePath ref)
+          result = (\a -> "module.exports = require('" ++ relative resourceDir (joinPath outputDir a) ++ "');") <$> moduleName
 
-  foreignPath <- if hasForeign
-                    then fromMaybe (pure Nothing) (findFFI ffiss <$> moduleName)
-                    else pure Nothing
+      liftEff do
+        clearDependencies ref
+        addDependency ref (resourcePath ref)
+        sequence $ (\src -> addDependency ref (resolve src)) <$> concat srcss
 
-  fromMaybe (pure unit) ((\path -> liftEff (addDependency ref path)) <$> foreignPath)
+      foreignPath <- if hasForeign
+                        then fromMaybe (pure Nothing) (findFFI ffiss <$> moduleName)
+                        else pure Nothing
 
-  spawn pscCommand (srcs <> opts)
+      fromMaybe (pure unit) ((\path -> liftEff (addDependency ref path)) <$> foreignPath)
 
-  return result
+      spawn pscCommand (srcs <> pscOpts)
+
+      return result
 
 loader :: forall eff. LoaderRef -> String -> Eff (Effects eff) Unit
 loader ref source = do


### PR DESCRIPTION
Fixes #15

Removes the `require-path` option and fixes it to '../'. When generating the temporary module for Webpack, use a relative path to the output directory so it doesn't need to be in `modulesDirectories`.