### PR TITLE
Bumping version number to 2.0.0-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Install with [npm](https://npmjs.org/package/purs-loader).
 
 ```
 npm install purs-loader --save-dev
+
+npm install purs-loader@next --save-dev
 ```
 
 ## Example
@@ -27,8 +29,7 @@ const webpackConfig = {
       exclude: /node_modules/,
       query: {
         psc: 'psa',
-        src: ['bower_components/purescript-*/src/**/*.purs', 'src/**/*.purs'],
-        ffi: ['bower_components/purescript-*/src/**/*.js', 'src/**/*.js'],
+        src: ['bower_components/purescript-*/src/**/*.purs', 'src/**/*.purs']
       }
     }
     // ...
@@ -59,11 +60,7 @@ Default options:
   src: [
     path.join('src', '**', '*.purs'),
     path.join('bower_components', 'purescript-*', 'src', '**', '*.purs')
-  ],
-  ffi: [
-    path.join('src', '**', '*.js'),
-    path.join('bower_components', 'purescript-*', 'src', '**', '*.js')
-  ],
+  ]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purs-loader",
-  "version": "1.0.0",
+  "version": "2.0.0-rc.0",
   "description": "A webpack loader for PureScript.",
   "main": "index.js",
   "files": [
@@ -34,10 +34,6 @@
     "url": "https://github.com/ethul/purs-loader/issues"
   },
   "homepage": "https://github.com/ethul/purs-loader#readme",
-  "peerDependencies": {
-    "webpack": ">=1.0.0 <3.0.0",
-    "purescript": ">=0.8.0"
-  },
   "dependencies": {
     "bluebird": "^3.3.5",
     "chalk": "^1.1.3",


### PR DESCRIPTION
Adds support for PureScript 0.9.1 and newer (purescript/purescript#2151)

The `next` tag on NPM points to this pre-release. Also note that
`peerDependencies` has been removed (npm/npm#8854).

Resolves #54