### PR TITLE
Fixes bundled output path

### DIFF
--- a/src/Psc.js
+++ b/src/Psc.js
@@ -86,7 +86,7 @@ function bundle(options, cache) {
         return reject(true)
       }
       cache.bundle = stderr
-      resolve(fs.appendFileAsync('output/bundle.js', `module.exports = ${options.bundleNamespace}`))
+      resolve(fs.appendFileAsync(options.bundleOutput, `module.exports = ${options.bundleNamespace}`))
     })
   }))
 }


### PR DESCRIPTION
Without this, specifying a bundled output path will fail. Particularly important for projects that have multiple outputs (you don't want your builds overwriting each other).