### PR TITLE
simplified psc args

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ const webpackConfig = {
       exclude: /node_modules/,
       query: {
         psc: 'psa',
+        pscArgs: '--censor-lib --censor-codes=ImplicitImport',
         src: ['bower_components/purescript-*/src/**/*.purs', 'src/**/*.purs']
       }
     }
@@ -51,9 +52,9 @@ Default options:
 ```javascript
 {
   psc: 'psc',
-  pscArgs: {},
+  pscArgs: "",
   pscBundle: 'psc-bundle',
-  pscBundleArgs: {},
+  pscBundleArgs: "",
   pscIde: false, // instant rebuilds using psc-ide-server (experimental)
   pscIdeColors: false, // defaults to true if psc === 'psa'
   bundleOutput: 'output/bundle.js',

--- a/src/Psc.js
+++ b/src/Psc.js
@@ -21,10 +21,10 @@ function compile(psModule) {
 
   cache.compilationStarted = true
 
-  const args = dargs(Object.assign({
+  const args = dargs({
     _: options.src,
     output: options.output,
-  }, options.pscArgs))
+  }).concat(options.pscArgs.split(" "))
 
   debug('spawning compiler %s %o', options.psc, args)
 
@@ -63,11 +63,11 @@ function bundle(options, cache) {
   const stdout = []
   const stderr = cache.bundle = []
 
-  const args = dargs(Object.assign({
+  const args = dargs({
     _: [path.join(options.output, '*', '*.js')],
     output: options.bundleOutput,
     namespace: options.bundleNamespace,
-  }, options.pscBundleArgs))
+  }).concat(options.pscBundleArgs.split(" "))
 
   cache.bundleModules.forEach(name => args.push('--module', name))
 

--- a/src/PscIde.js
+++ b/src/PscIde.js
@@ -61,9 +61,9 @@ function connect(psModule) {
     ideClient.stdin.write('\n')
   })
 
-  const args = dargs(Object.assign({
-    outputDirectory: options.output,
-  }, options.pscIdeArgs))
+  const args = dargs({
+    outputDirectory: options.output
+  }).concat(options.pscIdeArgs.split(" "))
 
   debug('attempting to start psc-ide-server', args)
 
@@ -103,7 +103,7 @@ function rebuild(psModule) {
   debug('attempting rebuild with psc-ide-client %s', psModule.srcPath)
 
   const request = (body) => new Promise((resolve, reject) => {
-    const args = dargs(options.pscIdeArgs)
+    const args = options.pscIdeArgs.split(" ")
     const ideClient = spawn('psc-ide-client', args)
 
     var stdout = ''


### PR DESCRIPTION
Thanks for the good work! I hope one day this becomes the de-facto build tool (over pulp)!

The current psc compiler flag API is in fact incomplete:

For example, right now it's impossible as I understand to pass in `--censor-codes=ImplicitImport` as a flag, as the current implementation splits key-value pairs by a space, and there is no way to write CamelCase arguments as keys.

This PR simplifies the compiler flag API to just take compiler args as a string; I can't imagine a need to configure these options programmatically anyways.
