### PR TITLE
add option for custom node path to invoke psa/psc

### DIFF
--- a/src/Psc.js
+++ b/src/Psc.js
@@ -26,12 +26,20 @@ function compile(psModule) {
     output: options.output,
   }, options.pscArgs))
 
-  debug('spawning compiler %s %o', options.psc, args)
-
   return (new Promise((resolve, reject) => {
     console.log('\nCompiling PureScript...')
 
-    const compilation = spawn(options.psc, args)
+    let compilation;
+
+    if (options.customNodePath) {
+      debug('spawning compiler %s %s %o', options.customNodePath, options.psc, args)
+
+      compilation = spawn(options.customNodePath, [options.psc, ...args])
+    }
+    else {
+      debug('spawning compiler %s %o', options.psc, args)
+      compilation = spawn(options.psc, args)
+    }
 
     compilation.stdout.on('data', data => stderr.push(data.toString()))
     compilation.stderr.on('data', data => stderr.push(data.toString()))


### PR DESCRIPTION
My shop is unable to install psc/psa/node globally on Windows so we need a way to invoke them with custom paths. This PR allows users to set a custom path with which to invoke node. If a path isn't supplied, it defaults to the old behavior and spawns psa/psc directly.