### PR TITLE
Minor README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,4 @@ Default options:
 
 Experimental support for instant rebuilds using `psc-ide-server` can be enabled
 via the `pscIde: true` option.
+You can use already running `psc-ide-server` instance - just define its port in `pscIdeArgs`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Default options:
   pscBundle: 'psc-bundle',
   pscBundleArgs: {},
   pscIde: false, // instant rebuilds using psc-ide-server (experimental)
+  pscIdeArgs: {}, // for example, to use different psc-ide-server port: {port: 4088}
   pscIdeColors: false, // defaults to true if psc === 'psa'
   bundleOutput: 'output/bundle.js',
   bundleNamespace: 'PS',


### PR DESCRIPTION
Probably we should also mention that this loader can be used with already running `psc-ide-server` instance. Should I add more info on the topic?