### PR TITLE
Add psc-ide-server arguments and pass src to psc-ide-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,18 @@ Default options:
 
 Experimental support for instant rebuilds using `psc-ide-server` can be enabled
 via the `pscIde: true` option.
-You can use an already running `psc-ide-server` instance by specifying the port in `pscIdeArgs`.
+You can use an already running `psc-ide-server` instance by specifying the port in `pscIdeArgs`,
+if there is no server running this loader will start one for you.
+
+
+#### Slower webpack startup after using purs-loader ?
+
+By default, the psc-ide-server will be passed the globs from query.src, this is
+helpful for other tools using psc-ide-server (for example IDE plugins), however
+it might result in a slower initial webpack startup time (rebuilds are not
+affected). To override the default behaviour, add:
+`pscIdeServerArgs: { "_": ['your/*globs/here'] }` to the loader config
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Default options:
   pscBundleArgs: {},
   pscIde: false, // instant rebuilds using psc-ide-server (experimental)
   pscIdeArgs: {}, // for example, to use different psc-ide-server port: {port: 4088}
+  pscIdeServerArgs: {}, // for example, to change the port { port: 4088 }
   pscIdeColors: false, // defaults to true if psc === 'psa'
   bundleOutput: 'output/bundle.js',
   bundleNamespace: 'PS',

--- a/src/PscIde.js
+++ b/src/PscIde.js
@@ -61,13 +61,14 @@ function connect(psModule) {
     ideClient.stdin.write('\n')
   })
 
-  const args = dargs(Object.assign({
+  const serverArgs = dargs(Object.assign({
     outputDirectory: options.output,
-  }, options.pscIdeArgs))
+    "_": options.src
+  }, options.pscIdeServerArgs))
 
-  debug('attempting to start psc-ide-server', args)
+  debug('attempting to start psc-ide-server', serverArgs)
 
-  const ideServer = cache.ideServer = spawn('psc-ide-server', [])
+  const ideServer = cache.ideServer = spawn('psc-ide-server', serverArgs)
   ideServer.stderr.on('data', data => {
     debug(data.toString())
   })


### PR DESCRIPTION
Should fix:
https://github.com/ethul/purs-loader/issues/79

For me this is also required for psc-ide-vim to work with the psc-ide-server instance started by purs-loader. 