### PR TITLE
initial psc-package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Refer to the [purescript-webpack-example](https://github.com/ethul/purescript-we
 Default options:
 
 ```javascript
-{
+const loaderConfig = {
   psc: 'psc',
   pscArgs: {},
   pscBundle: 'psc-bundle',
@@ -56,6 +56,7 @@ Default options:
   pscIdeArgs: {}, // for example, to use different psc-ide-server port: {port: 4088}
   pscIdeServerArgs: {}, // for example, to change the port { port: 4088 }
   pscIdeColors: false, // defaults to true if psc === 'psa'
+  pscPackage: false,
   bundleOutput: 'output/bundle.js',
   bundleNamespace: 'PS',
   bundle: false,
@@ -84,6 +85,6 @@ it might result in a slower initial webpack startup time (rebuilds are not
 affected). To override the default behaviour, add:
 `pscIdeServerArgs: { "_": ['your/*globs/here'] }` to the loader config
 
+### `psc-package` support (experimental)
 
-
-
+Set `pscPackage` query parameter to `true` and remove `src` parameter to enable `psc-package` support.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ const loaderConfig = {
   output: 'output',
   src: [
     path.join('src', '**', '*.purs'),
+    // if pscPackage = false
     path.join('bower_components', 'purescript-*', 'src', '**', '*.purs')
+    /*
+     * OR source paths reported by `psc-package sources`, if pscPackage = true
+     */
   ]
 }
 ```
@@ -87,4 +91,5 @@ affected). To override the default behaviour, add:
 
 ### `psc-package` support (experimental)
 
-Set `pscPackage` query parameter to `true` and remove `src` parameter to enable `psc-package` support.
+Set `pscPackage` query parameter to `true` to enable `psc-package` support. The `psc-package`-supplied source paths 
+will be appended to `src` parameter.

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ module.exports = function purescriptLoader(source, map) {
   const query = loaderUtils.parseQuery(this.query)
   const webpackOptions = this.options.purescriptLoader || {}
 
+  const depsPath = path.join('bower_components', 'purescript-*', 'src', '**', '*.purs');
+
   const options = Object.assign({
     context: config.context,
     psc: 'psc',
@@ -35,7 +37,7 @@ module.exports = function purescriptLoader(source, map) {
     output: 'output',
     src: [
       path.join('src', '**', '*.purs'),
-      path.join('bower_components', 'purescript-*', 'src', '**', '*.purs')
+      depsPath
     ]
   }, webpackOptions, query)
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ module.exports = function purescriptLoader(source, map) {
     }
   })
 
-  let options = Object.assign({
+  const defaultOptions = {
     context: config.context,
     psc: 'psc',
     pscArgs: {},
@@ -51,7 +51,9 @@ module.exports = function purescriptLoader(source, map) {
       path.join('src', '**', '*.purs'),
       ...depsPaths(query.pscPackage)
     ]
-  }, webpackOptions, query)
+  }
+
+  let options = Object.assign(webpackOptions, query)
 
   this.cacheable && this.cacheable()
 
@@ -62,6 +64,12 @@ module.exports = function purescriptLoader(source, map) {
     warnings: [],
     errors: []
   }
+
+  if (options.pscPackage && options.src) {
+    cache.warnings.push("purs-loader: src parameter is set - pscPackage parameter is ignored")
+  }
+
+  options = Object.assign(defaultOptions, options)
 
   if (!config.purescriptLoaderInstalled) {
     config.purescriptLoaderInstalled = true

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ module.exports = function purescriptLoader(source, map) {
 
   let options = Object.assign(webpackOptions, query)
 
+  const defaultDeps = depsPaths(options.pscPackage)
   const defaultOptions = {
     context: config.context,
     psc: 'psc',
@@ -51,7 +52,7 @@ module.exports = function purescriptLoader(source, map) {
     output: 'output',
     src: [
       path.join('src', '**', '*.purs'),
-      ...depsPaths(options.pscPackage)
+      ...defaultDeps
     ]
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ const PsModuleMap = require('./PsModuleMap');
 const Psc = require('./Psc');
 const PscIde = require('./PscIde');
 const dargs = require('./dargs');
+const spawn = require('cross-spawn').sync
+const eol = require('os').EOL
 
 const requireRegex = /require\(['"]\.\.\/([\w\.]+)['"]\)/g
 
@@ -19,9 +21,18 @@ module.exports = function purescriptLoader(source, map) {
   const query = loaderUtils.parseQuery(this.query)
   const webpackOptions = this.options.purescriptLoader || {}
 
-  const depsPath = path.join('bower_components', 'purescript-*', 'src', '**', '*.purs');
+  const depsPaths = (pscPackage => {
+    if (pscPackage) {
+      debug('calling psc-package...')
 
-  const options = Object.assign({
+      return spawn('psc-package', ['sources']).stdout.toString().split(eol).filter(v => v != '')
+    }
+    else {
+      return [ path.join('bower_components', 'purescript-*', 'src', '**', '*.purs') ]
+    }
+  })
+
+  let options = Object.assign({
     context: config.context,
     psc: 'psc',
     pscArgs: {},
@@ -30,6 +41,7 @@ module.exports = function purescriptLoader(source, map) {
     pscIde: false,
     pscIdeColors: webpackOptions.psc === 'psa' || query.psc === 'psa',
     pscIdeArgs: {},
+    pscPackage: false,
     bundleOutput: 'output/bundle.js',
     bundleNamespace: 'PS',
     bundle: false,
@@ -37,7 +49,7 @@ module.exports = function purescriptLoader(source, map) {
     output: 'output',
     src: [
       path.join('src', '**', '*.purs'),
-      depsPath
+      ...depsPaths(query.pscPackage)
     ]
   }, webpackOptions, query)
 

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ module.exports = function purescriptLoader(source, map) {
   }
 
   if (options.pscPackage && options.src) {
-    cache.warnings.push("purs-loader: src parameter is set - pscPackage parameter is ignored")
+    options.src = options.src.concat(defaultDeps) // append psc-package-provided source paths with users'
   }
 
   options = Object.assign(defaultOptions, options)

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,8 @@ module.exports = function purescriptLoader(source, map) {
     }
   })
 
+  let options = Object.assign(webpackOptions, query)
+
   const defaultOptions = {
     context: config.context,
     psc: 'psc',
@@ -49,11 +51,9 @@ module.exports = function purescriptLoader(source, map) {
     output: 'output',
     src: [
       path.join('src', '**', '*.purs'),
-      ...depsPaths(query.pscPackage)
+      ...depsPaths(options.pscPackage)
     ]
   }
-
-  let options = Object.assign(webpackOptions, query)
 
   this.cacheable && this.cacheable()
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ module.exports = function purescriptLoader(source, map) {
     pscBundle: 'psc-bundle',
     pscBundleArgs: {},
     pscIde: false,
-    pscIdeColors: webpackOptions.psc === 'psa' || query.psc === 'psa',
+    pscIdeColors: options.psc === 'psa',
     pscIdeArgs: {},
     pscPackage: false,
     bundleOutput: 'output/bundle.js',


### PR DESCRIPTION
Initial and very basic support of `psc-package`. Sort of works with `purescript-webpack-example` (deps' paths are supplied to compiler, but compilation still fails)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethul/purs-loader/82)
<!-- Reviewable:end -->
