### PR TITLE
Don’t unnecessarily invalidate the module map

### DIFF
--- a/src/to-javascript.js
+++ b/src/to-javascript.js
@@ -123,7 +123,7 @@ function makeJS(psModule, psModuleMap, js) {
     }
 
     return updatingPsModuleMap.then(updatedPsModuleMap => {
-      const additionalImportsResult = additionalImports.map(import_ => {
+      const missingImportsResult = missingImports.map(import_ => {
         const moduleValue = updatedPsModuleMap[import_];
 
         if (!moduleValue) {
@@ -138,7 +138,7 @@ function makeJS(psModule, psModuleMap, js) {
         }
       }).filter(a => a !== null).join('\n');
 
-      return result + '\n' + additionalImportsResult;
+      return result + '\n' + missingImportsResult;
     });
   }
 }

--- a/src/to-javascript.js
+++ b/src/to-javascript.js
@@ -109,11 +109,20 @@ function makeJS(psModule, psModuleMap, js) {
     return Promise.resolve(result);
   }
   else {
-    debug('rebuilding module map due to additional imports for %s: %o', name, additionalImports);
+    const missingImports = additionalImports.filter(moduleName =>
+        !psModuleMap[moduleName] && moduleName.split('.')[0] !== 'Prim'
+    );
 
-    psModule.cache.psModuleMap = null;
+    let updatingPsModuleMap;
+    if (missingImports.length > 0) {
+        debug('rebuilding module map due to missing imports for %s: %o', name, missingImports);
+        psModule.cache.psModuleMap = null;
+        updatingPsModuleMap = updatePsModuleMap(psModule);
+    } else {
+        updatingPsModuleMap = Promise.resolve(psModuleMap);
+    }
 
-    return updatePsModuleMap(psModule).then(updatedPsModuleMap => {
+    return updatingPsModuleMap.then(updatedPsModuleMap => {
       const additionalImportsResult = additionalImports.map(import_ => {
         const moduleValue = updatedPsModuleMap[import_];
 


### PR DESCRIPTION
Additional imports in PureScript sources (compared to their JavaScript output) shouldn’t always invalidate the module map because imports of types are erased and re-exports are followed.

Also `Prim.*` modules are internal to the compiler and won’t ever be present in the module map.

Fix https://github.com/ethul/purs-loader/issues/123.