### PR TITLE
Use 'spago path output' to choose default output path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ function getSpagoSources() {
     throw new Error(error);
   }
   else {
-    const result = cmd.stdout.toString();
+    const result = cmd.stdout.toString().split(eol)[0]
 
     debug('"spago path output" result: %o', result);
 


### PR DESCRIPTION
Hi!

This PR uses `spago output path` command to set the default output path. This is used in monorepos to set a shared output folder to save repeatedly building things.

Thanks!
Dan