### PR TITLE
Readme: Default to spago instead of bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ const webpackConfig = {
       loader: 'purs-loader',
       exclude: /node_modules/,
       query: {
-        psc: 'psa',
-        src: ['bower_components/purescript-*/src/**/*.purs', 'src/**/*.purs']
+        spago: true,
+        pscIde: true,
+        src: ['src/**/*.purs']
       }
     }
     // ...


### PR DESCRIPTION
Hi there,

I'm fairly new to PureScript. I noticed the default example in the `README` uses bower. I thought it would be nice to use `spago` instead, because it seems to be the new ecosystem's choice.

Feel free to adjust the PR to your likings:
![image](https://user-images.githubusercontent.com/13085980/89336813-450cdd00-d69a-11ea-9bdc-065c19d0ac38.png)
