### PR TITLE
Show error message in case of compile error

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -51,7 +51,7 @@ module.exports = function compile(psModule) {
           resolve(psModule);
         }
         else {
-          reject(new Error('compilation failed'))
+          reject(new Error('compilation failed: ' + errorMessage))
         }
       } else {
         const warningMessage = stderr.join('');


### PR DESCRIPTION
If the project is in a *non-compiling state before running webpack*:

With a compile error the output looks like this:

```
Creating an optimized production build...
Failed to compile.

./src/Main.purs
Error: compilation failed


npm ERR! code ELIFECYCLE
npm ERR! errno 1
```

or

![image](https://user-images.githubusercontent.com/13085980/91750075-c20c7300-ebc2-11ea-8b02-adea3528f7c2.png)


For comparison, the error of `spago build`:

```
Compiling Root
Error found:
in module Root
at src/Root.purs:26:7 - 26:10 (line 26, column 7 - line 26, column 10)

  Unknown value log


See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
or to contribute content related to this error.


[error] Failed to build.
```

Therefore I would suggest appending the error message. Not sure if this could lead to duplicates though.

# Result

```
./src/Main.purs
Error: compilation failed: Error found:
in module Root
at src/Root.purs:26:7 - 26:10 (line 26, column 7 - line 26, column 10)

  Unknown value log

See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
or to contribute content related to this error.


npm ERR! code ELIFECYCLE
npm ERR! errno 1
```

![image](https://user-images.githubusercontent.com/13085980/91750170-ec5e3080-ebc2-11ea-9c0f-cea16499b093.png)
