### PR TITLE
Catch stdin errors of pscide

### DIFF
--- a/src/ide.js
+++ b/src/ide.js
@@ -70,6 +70,14 @@ function spawnIdeClient(body, options) {
       }
     })
 
+    ideClient.stdin.on("error", e =>  {
+      stderr.push(e.toString());
+    });
+
+    ideClient.on("error", e => {
+      stderr.push(e.toString());
+    });
+
     ideClient.stdin.resume();
 
     ideClient.stdin.write(JSON.stringify(body));


### PR DESCRIPTION
I debugged a bit and I think it's errors on stdin occurring if another process is using `purs ide`, too. It looks like simply catching this case, is solving the issue, because the error won't kill the process anymore. It's working afterwards.

I could reproduce it solving the issue #155 and also that the issue will come back with the current version.

Solves #155