### PR TITLE
Integrate zephyr dead code elimination

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -12,6 +12,8 @@ const debugVerbose = debug_('purs-loader:verbose');
 
 const dargs = require('./dargs');
 
+const zephyr = require('./zephyr');
+
 module.exports = function compile(psModule) {
   const options = psModule.options
 
@@ -20,6 +22,7 @@ module.exports = function compile(psModule) {
   const compileArgs = (options.psc ? [] : [ 'compile' ]).concat(dargs(Object.assign({
     _: options.src,
     output: options.output,
+    codegen: options.zephyr ? "js,corefn" : undefined
   }, options.pscArgs)))
 
   const stderr = [];
@@ -58,7 +61,13 @@ module.exports = function compile(psModule) {
         if (options.warnings && warningMessage.length) {
           psModule.emitWarning(warningMessage);
         }
-        resolve(psModule)
+
+        // zephyr dead code elimination
+        if(options.zephyr) {
+          zephyr(psModule).then(resolve);
+        } else {
+          resolve(psModule)
+        }
       }
     })
   });

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,7 @@ module.exports = function purescriptLoader(source, map) {
     bundle: false,
     warnings: true,
     watch: false,
+    zephyr: false,
     output: outputPath,
     src: []
   }, loaderOptions, {

--- a/src/zephyr.js
+++ b/src/zephyr.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const Promise = require('bluebird');
+
+const spawn = require('cross-spawn');
+
+const debug_ = require('debug');
+
+const debug = debug_('purs-loader');
+
+module.exports = function compile(psModule) {
+  const options = psModule.options
+
+  const zephyrCommand = 'zephyr';
+  const zephyrArgs = [ psModule.name, "-i", options.output, "-o", options.output ];
+
+  debug('zephyr %s %O', zephyrCommand, zephyrArgs)
+
+  return new Promise((resolve, reject) => {
+    debug('Running zephyr...')
+
+    const zephyr = spawn(zephyrCommand, zephyrArgs)
+
+    zephyr.on('close', code => {
+      debug('finished compiling zephyr.')
+      if (code !== 0) {
+        psModule.emitError("Zephyr failed");
+        reject(new Error('Zephyr failed'))
+      } else {
+        resolve(psModule);
+      }
+    })
+  });
+};


### PR DESCRIPTION
Hi, 

I wanted to see how much effect [`zephyr`](https://github.com/coot/zephyr) dead code elimination would have on a production build. It shaved of ~ 80 kb (gzipped) / 535 kb (zipped) / 50+ % (if I'm not mistaken).

So I'm sold on trying to integrate it in the build. Here is a draft PR, that shows the current integration.

If you want to give it a try, there is a pre-compiled branch and you can use it like this in  `package.json`:

```
    "purs-loader": "andys8/purs-loader#poc/zephyr-build",
```

## Discussion

I've still open questions. That's why this is a draft.

* The README says there is already dead code elimination. Can you provide details what is meant?
* This needs to be integrated into `bundle`. I'm not using `bundle` so far, because it will fail resolving TypeScript/Assets for me. It should be done. I can't test it.
* What details are missing for documentation?
* I'm currently re-using the configured `output` directory both for the compile and zephyr step. This avoids created a temporary folder. It seems to work fine for me. Could this lead to issues?

## Issues

Closes #143 