### PR TITLE
Quality of Life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ const loaderConfig = {
   pscIdeColors: false, // defaults to true if psc === 'psa'
   pscPackage: false, // include dependencies from psc-package
   spago: false, // include dependencies from spago
+  spagoDhall: null, // if set, uses the specified spago config (i.e., spago -x spagoDhall ...)
   bundleOutput: 'output/bundle.js',
   bundleNamespace: 'PS',
   bundle: false,

--- a/src/compile.js
+++ b/src/compile.js
@@ -36,6 +36,16 @@ module.exports = function compile(psModule) {
     });
 
     compilation.stdout.on('data', data => {
+      // NB: it seems like the actual error details are printed to stdout
+      // (at least on 0.15). So without this, you'll just get an error line
+      // saying what file has the error, but not what the error is...
+      //
+      // Combined with the `stderr` of each file being combined above,
+      // this has the unfortunate side effect of printing every file
+      // compiled as a warning (assuming compilation succeeds).
+      //
+      // purs has --json-errors, and we should really be taking advantage of it here...
+      stderr.push(data.toString());
       debugVerbose(data.toString());
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,8 @@ var CACHE_VAR = {
 
 // include src files provided by psc-package or Spago
 function requestDependencySources(packagerCommand, srcPath, loaderOptions) {
-  const packagerArgs = ['sources'];
+  const spagoDhall = loaderOptions.spago ? loaderOptions.spagoDhall : null;
+  const packagerArgs = spagoDhall ? ['-x', spagoDhall, 'sources'] : ['sources'];
 
   const loaderSrc = loaderOptions.src || [
     srcPath
@@ -75,13 +76,13 @@ function requestDependencySources(packagerCommand, srcPath, loaderOptions) {
 }
 
 // 'spago output path' will return the output folder in a monorepo
-function getSpagoSources() {
+function getSpagoSources(spagoDhall) {
   const cachedVal = CACHE_VAR.spagoOutputPath;
   if (cachedVal) {
     return cachedVal
   }
   const command = "spago"
-  const args = ["path", "output"]
+  const args = spagoDhall ? ["-x", spagoDhall, "path", "output"] : ["path", "output"];
 
   const cmd = spawn(command, args);
 
@@ -139,7 +140,7 @@ module.exports = function purescriptLoader(source, map) {
     }
   })(loaderOptions.pscPackage, loaderOptions.spago);
   
-  const outputPath = loaderOptions.spago ? getSpagoSources() : 'output'
+  const outputPath = loaderOptions.spago ? getSpagoSources(loaderOptions.spagoDhall) : 'output'
 
   const options = Object.assign({
     context: webpackContext,
@@ -156,6 +157,7 @@ module.exports = function purescriptLoader(source, map) {
     pscIdeColors: loaderOptions.psc === 'psa',
     pscPackage: false,
     spago: false,
+    spagoDhall: null,
     bundleOutput: 'output/bundle.js',
     bundleNamespace: 'PS',
     bundle: false,


### PR DESCRIPTION
Hello! Just a couple of quality-of-life improvements when using purs-loader

### Preserve error details when compilation fails.
It seems like `purs` prints what file it's compiling to stderr, but any error messages/warnings to stdout. This means that when you have a compile error, webpack (and `webpack-dev-server` with the cute overlay) will just show /what module/ failed to build, instead of the actual error. This is obviously undesirable. I've left a note to start using `--json-errors`, since it would make distinguishing between the outputs much more straightforward, but for the time being this suffices

### Support overriding `spago.dhall` 
As we know, spago (as of today) does not support multiple projects in one repo, and the workaround is to have multiple `dhall` files for each project, and invoking `spago -x <blah>.dhall`. If you have such a setup in a purs+webpack project, there's actually no way to tell `purs-loader` how to properly invoke `spago`. This adds `spagoDhall: string | null` as a field to the loader options, and when it's present, will pass `-x <spagoDhall>` when invoking spago. (i.e., when `{ options: { spago: true }`).
