### PR TITLE
Allow overriding output in loader options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const loaderConfig = {
   bundle: false,
   warnings: true,
   watch: false, // indicates if webpack is in watch mode
-  output: 'output',
+  output: 'output', // if not specified and spago = true, then as reported by `spago path output`
   src: [
     path.join('src', '**', '*.purs'),
     // if pscPackage = true

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ module.exports = function purescriptLoader(source, map) {
     }
   })(loaderOptions.pscPackage, loaderOptions.spago);
   
-  const outputPath = loaderOptions.spago ? getSpagoSources() : 'output'
+  const outputPath = loaderOptions.output || (loaderOptions.spago ? getSpagoSources() : 'output')
 
   const options = Object.assign({
     context: webpackContext,


### PR DESCRIPTION
Hey. A new version of Spago is in the works (see https://github.com/purescript/spago) and it no longer supports `spago path output` as a way to tell the path to the output dir.

This PR is a stopgap. While it does not provide a way to get that path with the new spago version, it allows to override the logic  of getting it with `spago path output` by accepting `output` as a loader param and using that if it's present.

Also thanks for your work on the loader! It really eliminates friction from purs development for the web.